### PR TITLE
Implement `crop_to_polygon` feature.

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -18,7 +18,7 @@ a tiled fashion, and to many other additional operations.
 #### \_\_init\_\_
 
 ```python
-def __init__(file=None)
+def __init__(file=None, memory_file=None)
 ```
 
 Initializes a GeoTiff object.
@@ -26,21 +26,18 @@ Initializes a GeoTiff object.
 **Arguments**:
 
 - `file`: A file object for the geotiff.
-
-- `memory_file`: The corresponding opened `MemoryFile` object if the geotiff is stored in memory.
-            In most cases, this is simply left as None for all geotiffs that are stored on disk.
-
-**Properties**:
-- `dataset`: open geotiff file
-- `size`: tuple -> raster width, height
-- `bands`: int -> number of bands in geotiff
-- `transform`: the dataset's geospatial transform - an affine transformation matrix that maps pixel
+- `memory_file`: The corresponding opened MemoryFile object if the geotiff is stored in memory.
+Properties:
+dataset : open geotiff file
+size : tuple -> raster width, height
+bands : int -> number of bands in geotiff
+transform : the dataset's geospatial transform - an affine transformation matrix that maps pixel
             locations in (row, col) coordinates to (x, y) spatial positions
-- `corners`: array of lat/long of corners, in order top left, top right, bottom right, bottom left
-- `block_shapes`: array with the shape of blocks for all bands
+corners : array of lat/long of corners, in order top left, top right, bottom right, bottom left
+block_shapes : array with the shape of blocks for all bands
                 i.e [(1, (3, 791)), (2, (3, 791))]
-- `profile`: Geotiff profile - used for writing metadata to new file
-- `memory_file`: the associated memory file object if geotiff is stored in memory
+profile : Geotiff profile - used for writing metadata to new file
+memory_file : the associated memory file object if geotiff is stored in memory
 
 <a id="scgt.GeoTiff.__enter__"></a>
 
@@ -90,18 +87,15 @@ the GeoTiff object.
 def copy_to_new_file(cls, filename, profile, no_data_value=None)
 ```
 
-Creates a new file to store empty GeoTiff obj with specified params.
+creates a new file to store empty GeoTiff obj with specified params.
 
-**Arguments**:
-- `filename`: file name to which to copy the file.
-- `profile`: profile for writing the geotiff.
-- `no_data_value` (dtype of raster): value to be used as transparent 'nodata' value, otherwise fills 0's
+:param filename: file name to which to copy the file.
+:param profile: profile for writing the geotiff.
+:param no_data_value (dtype of raster): value to be used as transparent 'nodata' value, otherwise fills 0's
     (note that if geotiff is of unsigned type, like uint8, the no_data value must be  a positive int in the data
     range, which could result in data obstruction. If datatype is signed, we suggest using a negative value)
+:return: the GeoTiff object for the new file.
 
-**Returns**:
-
-the GeoTiff object for the new file.
 
 <a id="scgt.GeoTiff.create_memory_file"></a>
 
@@ -112,17 +106,13 @@ the GeoTiff object for the new file.
 def create_memory_file(cls, profile, no_data_value=None)
 ```
 
-Creates a temporary file in memory in which to store a GeoTiff obj.
+creates a temporary file in memory in which to store a GeoTiff obj.
 
-**Arguments**:
-- `profile`: profile for writing the geotiff.
-- `no_data_value` (dtype of raster): value to be used as transparent 'nodata' value, otherwise fills 0's
-    (note that if geotiff is of unsigned type, like uint8, the no_data value must be  a positive int in the data
-    range, which could result in data obstruction. If datatype is signed, we suggest using a negative value)
+:param profile: profile for writing the geotiff.
+:param no_data_value (dtype of raster): value to be used as transparent 'nodata' value, otherwise fills 0's
+    (note that if geotiff is of unsigned type, like uint8, the no_data value must be  a positive int in the data range, which could result in data obstruction. If datatype is signed, we suggest using a negative value)
+:return: the GeoTiff object for the new file.
 
-**Returns**:
-
-the GeoTiff object for the new file.
 
 <a id="scgt.GeoTiff.clone_shape"></a>
 
@@ -134,16 +124,12 @@ def clone_shape(filename, no_data_value=None, dtype=None)
 
 Creates a new geotiff with the indicated filename, cloning the shape of the current one.
 
-**Arguments**:
-- `filename`: filename where to create the new clone.
-- `no_data_value` (dtype of raster): value to be used as transparent 'nodata' value, otherwise fills 0's
+:param filename: filename where to create the new clone.
+:param no_data_value (dtype of raster): value to be used as transparent 'nodata' value, otherwise fills 0's
     (note that if geotiff is of unsigned type, like uint8, the no_data value must be  a positive int in the data
     range, which could result in data obstruction. If datatype is signed, we suggest using a negative value)
-- `dtype` (str): datatype of tiff (ref: https://github.com/rasterio/rasterio/blob/master/rasterio/dtypes.py#L21)
-
-**Returns**:
-
-the GeoTiff object for the new file.
+:param dtype (str): datatype of tiff (ref: https://github.com/rasterio/rasterio/blob/master/rasterio/dtypes.py#L21)
+:return: the GeoTiff object for the new file.
 
 
 <a id="scgt.GeoTiff.scale_tiff"></a>
@@ -227,6 +213,26 @@ Gets pixel on the geotiff that corresponds to the CRS coordinate given
 **Returns**:
 
 (x,y) pixel of geotiff which corresponds to coord, or None if out of bounds
+
+<a id="scgt.GeoTiff.get_coord_from_pixel"></a>
+
+#### get\_coord\_from\_pixel
+
+```python
+def get_coord_from_pixel(xy, offset='center')
+```
+
+Gets CRS coordinate that corresponds to the (x, y) pixel on the geotiff
+
+**Arguments**:
+
+- `xy`: (x,y) pixel of geotiff
+- `offset`: defines whether to return one of the corner coordinates or the center
+coordinates of the pixel; must be one of 'center', 'ul', 'ur', 'll', 'lr'
+
+**Returns**:
+
+the corresponding CRS coordinate, or None if out of bounds
 
 <a id="scgt.GeoTiff.get_tile_from_coord"></a>
 
@@ -379,7 +385,7 @@ def getAttributeTable()
 ```
 
 Opens geotiff with GDAL, creates attribute table containing tiff's unique values and counts.
-To be called in __exit__ as to update the RAT with any new values
+To be called in __exit__ as to update the RAT with any new values.
 
 <a id="scgt.GeoTiff.draw_geotiff"></a>
 
@@ -412,7 +418,27 @@ Create a new geotiff by cropping the current one and writing to a new file.
 - `bounds`: bounding box (xmin, ymin, xmax, ymax) for the output (in the same coordinate system)
 - `padding`: amount of padding in meters to add around the shape bounds.
 - `filename`: path where to write result.
-- `in_memory`: whether to create the file in memory only. `filename` is ignored if True.
+- `in_memory`: whether to create the file in memory only. filename is ignored if True.
+
+**Returns**:
+
+the GeoTiff object for the new file.
+
+<a id="scgt.GeoTiff.crop_to_polygon"></a>
+
+#### crop\_to\_polygon
+
+```python
+def crop_to_polygon(polygon, filename=None, in_memory=False)
+```
+
+Crop the GeoTIFF using a specified polygon and save to a new file or return in-memory file.
+
+**Arguments**:
+
+- `polygon`: A Shapely polygon specifying the area to crop. Should be in same coordinate system.
+- `filename`: The path where the cropped GeoTIFF should be saved.
+- `in_memory`: whether to create the file in memory only. filename is ignored if True.
 
 **Returns**:
 
@@ -526,7 +552,6 @@ Closes the memory file if the GeoTiff object is created in memory only.
 This is called automatically if the object is used in a with statement.
 Otherwise, it should be called when the GeoTiff object is not needed anymore
 so that the memory file is deleted.
-
 
 <a id="scgt.Reader"></a>
 


### PR DESCRIPTION
Solves the issue mentioned [here](https://github.com/ecoscape-earth/ecoscape-browser/issues/34#issuecomment-2087768662).
I believe we need the ability to crop GeoTIFFs to a polygon instead of just according to an axis-aligned bounding box. I tested my implementation and it appears to behave correctly, but please double check if anything looks immediately wrong.